### PR TITLE
Add hugo.barrera.io to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -393,6 +393,7 @@ hoppscotch.io
 hostedtalk.net
 hotstar.com
 htmlpasta.com
+hugo.barrera.io
 humblebundle.com/$
 humblebundle.com/accessibility
 humblebundle.com/charities


### PR DESCRIPTION
Since #6994 is not implemented, this seems necessary.