### PR TITLE
Add Neeva.com to global dark list

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -532,6 +532,7 @@ nanhu.ca
 nchristopher.me
 neal.fun/size-of-space
 nee.lv
+neeva.com
 neovim.io
 neundex.com
 newgrounds.com


### PR DESCRIPTION
Neeva has its own dark mode that one can set on the top right of its interface.

![Neeva Dark Mode](https://user-images.githubusercontent.com/3530333/163514124-0a2f3aac-7168-4f12-88e5-24e2b80c1c83.png)