### PR TITLE
Add codeberg.org to dark sites

### DIFF
--- a/src/config/dark-sites.config
+++ b/src/config/dark-sites.config
@@ -144,6 +144,7 @@ cinema-city.pl
 clash3d.com
 clashofstats.com
 clt.gg
+codeberg.org
 codepen.io
 codesandbox.io
 codestackr.com


### PR DESCRIPTION
Codeberg is a popular site, and its theme is dark by default.